### PR TITLE
chore: bump qs to 6.15.3 for Dependabot security alerts (SK-1438)

### DIFF
--- a/prototyping/local-server/package-lock.json
+++ b/prototyping/local-server/package-lock.json
@@ -1153,12 +1153,13 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.6"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -1290,14 +1291,14 @@
       "license": "ISC"
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -1309,13 +1310,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"

--- a/prototyping/local-server/package.json
+++ b/prototyping/local-server/package.json
@@ -19,5 +19,8 @@
     "@types/jsonwebtoken": "^9.0.5",
     "ts-node": "^10.9.2",
     "typescript": "^5.3.3"
+  },
+  "overrides": {
+    "qs": "6.15.3"
   }
 }


### PR DESCRIPTION
## Summary
- Force `qs@6.15.3` via npm `overrides` in `prototyping/local-server` (transitive dep of express/body-parser was pinned at `6.13.0`).
- Clears open Dependabot alerts:
  - GHSA-6rw7-vpxm-498p / CVE-2025-15284 (moderate) — fixed in ≥6.14.1
  - GHSA-w7fw-mjwx-w883 / CVE-2026-2391 (low) — fixed in ≥6.14.2
  - GHSA-q8mj-m7cp-5q26 / CVE-2026-8723 (moderate) — fixed in ≥6.15.2

## Notes
- Security-only change; no intentional feature dependency upgrades.
- Other lockfile packages may still report npm audit findings that are already dismissed or not currently open Dependabot alerts (e.g. axios, form-data, path-to-regexp).

## Test plan
- [ ] Confirm Dependabot alerts #5, #10, #29 auto-close after merge
- [ ] `npm ci` in `prototyping/local-server` resolves `qs@6.15.3`